### PR TITLE
Fix: Header team section not working #97

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 					<li class="current"><a href="#body">Home</a></li>
 					<li><a href="#features">Aim</a></li>
 					<li><a href="#works">Events</a></li>
-					<li><a href="https://eduhubcommunity.tech/eduhub-website/1.0/TeamPage.html">Team</a></li>
+					<li><a href="#team">Team</a></li>
 					<li><a href="#contact">Contact</a></li>
 				</ul>
 			</nav>
@@ -557,7 +557,7 @@
         Meet Our Team
         ==================================== -->
 
-	<section class="section-team team">
+	<section id="team" class="section-team team">
 			<div class="container">
 				<!-- Start Header Section -->
 				<div class="row justify-content-center text-center">


### PR DESCRIPTION
The `team` div was lacking an ID named `team`, which is necessary to in order to navigate to the "team" div from the navbar's Team link.

Also, the "Team" link in the navbar has it's `href` attribute set to `https://eduhubcommunity.tech/eduhub-website/1.0/TeamPage.html` instead of `#team`. 

I have applied the necessary fix and now the Team link works :)